### PR TITLE
Visionreq

### DIFF
--- a/visionreq.txt
+++ b/visionreq.txt
@@ -46,7 +46,7 @@ jedi=0.13.1=py36_1000
 jinja2=2.10=py_1
 jpeg=9c=h470a237_1
 jsonschema=3.0.0a3=py36_1000
-jupyter_client=5.2.4=py_0
+jupyter_client=5.2.4=py_2
 jupyter_contrib_core=0.3.3=py_2
 jupyter_contrib_nbextensions=0.5.0=py36_1000
 jupyter_core=4.4.0=py_0


### PR DESCRIPTION
Actualizo los paquetes de visionreq que dejan de estar disponibles.

Actualizo el paquete jupyter_client a su versión 5.2.4 (py_2).